### PR TITLE
Implement findColor function

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,13 @@ const COLORS = ['red', 'green', 'blue', 'yellow', 'pink', 'orange'];
 // given a hash, return the color that created the hash
 function findColor(hash) {
     // code here
+    var colour = COLORS.find(element => {
+        const abytes = utf8ToBytes(element);
+        const hashed = sha256(abytes);
+        return toHex(hashed) === toHex(hash)
+    })
+    return colour;
+    
 }
 
 module.exports = findColor;


### PR DESCRIPTION
Initially I used the array.find() method to find the element whose hash in hexadecimal form is equal to the given hash in findColor function. 
<br>
**Issues faced**  :  I did not convert the hash in the parameter into hexadecimal form so the test cases did not run properly
<br>
Output : 
![Screenshot from 2024-09-11 04-42-47](https://github.com/user-attachments/assets/f24a91c5-3dcd-40a7-b806-7ddfdcd9d877)

